### PR TITLE
feat: Add category selection for CSS import/export and JSON export

### DIFF
--- a/app.css
+++ b/app.css
@@ -595,15 +595,9 @@ input[type="checkbox"]:checked::before {
   border-radius: 4px;
   transition: background-color 0.2s, color 0.2s, stroke 0.2s;
 }
-.icon-btn svg {
-  /*stroke: var(--text-secondary);*/
-}
 .icon-btn:hover {
   background-color: var(--bg-tertiary);
   color: var(--text-primary);
-}
-.icon-btn:hover svg {
-  /* stroke: var(--text-primary); */
 }
 .icon-btn:hover svg path[fill] {
   fill: var(--grey-450);
@@ -685,7 +679,8 @@ input[type="checkbox"]:checked::before {
   margin-bottom: 8px;
 }
 .form-group input,
-.form-group select {
+.form-group select,
+.form-control {
   width: 100%;
   padding: 10px 12px;
   background-color: var(--bg-secondary);
@@ -695,7 +690,8 @@ input[type="checkbox"]:checked::before {
   transition: border-color 0.2s;
 }
 .form-group input:focus,
-.form-group select:focus {
+.form-group select:focus,
+.form-control:focus {
   border-color: var(--accent-primary);
 }
 
@@ -808,6 +804,135 @@ input[type="checkbox"]:checked::before {
 #delete-confirm-details ul {
   list-style: none;
   padding-left: 0;
+}
+
+/* Custom Select Styling */
+.custom-select-wrapper {
+    position: relative;
+    display: block;
+    width: 100%;
+}
+
+.custom-select {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-secondary);
+    border-radius: 6px;
+    padding: 10px 40px 10px 12px;
+    font-size: 14px;
+    color: var(--text-primary);
+    width: 100%;
+    cursor: pointer;
+    transition: all 0.2s;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23736c64' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    background-size: 16px;
+}
+
+.custom-select:focus {
+    border-color: var(--accent-primary);
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(112, 214, 255, 0.2);
+}
+
+.custom-select:hover {
+    border-color: var(--grey-400);
+}
+
+.custom-select option {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    padding: 8px 12px;
+}
+
+/* Category Selection Group */
+.category-selection-group {
+    margin: 1.5rem 0;
+    padding: 1rem;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    border: 1px solid var(--border-secondary);
+}
+
+.category-selection-group label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    color: var(--text-primary);
+    font-size: 14px;
+}
+
+.category-selection-help {
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-top: 0.5rem;
+    font-style: italic;
+}
+
+/* Multi-select category list for export */
+.category-export-list {
+    max-height: 300px;
+    overflow-y: auto;
+    border: 1px solid var(--border-secondary);
+    border-radius: 6px;
+    background: var(--bg-main);
+}
+
+.category-export-header {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-secondary);
+    background: var(--bg-secondary);
+    font-weight: 600;
+}
+
+.category-export-header label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    cursor: pointer;
+}
+
+.category-export-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-primary);
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.category-export-item:hover {
+    background: var(--bg-tertiary);
+}
+
+.category-export-item:last-child {
+    border-bottom: none;
+}
+
+.category-export-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+}
+
+.category-export-name {
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.category-export-count {
+    font-size: 12px;
+    color: var(--text-secondary);
+    background: var(--grey-800);
+    padding: 2px 8px;
+    border-radius: 10px;
+    margin-left: auto;
 }
 
 /* --- Toast Notifications --- */

--- a/index.html
+++ b/index.html
@@ -1,45 +1,50 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    
+
     <!-- Primary Meta Tags -->
     <title>Bricks Variable Manager - CSS Custom Properties Management Tool</title>
     <meta name="title" content="Bricks Variable Manager - CSS Custom Properties Management Tool">
-    <meta name="description" content="A powerful web application for managing CSS custom properties and design tokens. Perfect for Bricks WordPress users and design system management with import/export capabilities.">
-    <meta name="keywords" content="CSS variables, custom properties, design tokens, Bricks WordPress, design system, CSS management, web development tools">
+    <meta name="description"
+        content="A powerful web application for managing CSS custom properties and design tokens. Perfect for Bricks WordPress users and design system management with import/export capabilities.">
+    <meta name="keywords"
+        content="CSS variables, custom properties, design tokens, Bricks WordPress, design system, CSS management, web development tools">
     <meta name="author" content="Bricks Variable Manager">
     <meta name="robots" content="index, follow">
-    
+
     <!-- Theme Color -->
     <meta name="theme-color" content="#70d6ff">
     <meta name="msapplication-TileColor" content="#70d6ff">
-    
+
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="">
     <meta property="og:title" content="Bricks Variable Manager - CSS Custom Properties Management Tool">
-    <meta property="og:description" content="A powerful web application for managing CSS custom properties and design tokens. Perfect for Bricks WordPress users and design system management.">
+    <meta property="og:description"
+        content="A powerful web application for managing CSS custom properties and design tokens. Perfect for Bricks WordPress users and design system management.">
     <meta property="og:image" content="./og-image.png">
     <meta property="og:site_name" content="Bricks Variable Manager">
-    
+
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="">
     <meta property="twitter:title" content="Bricks Variable Manager - CSS Custom Properties Management Tool">
-    <meta property="twitter:description" content="A powerful web application for managing CSS custom properties and design tokens. Perfect for Bricks WordPress users and design system management.">
+    <meta property="twitter:description"
+        content="A powerful web application for managing CSS custom properties and design tokens. Perfect for Bricks WordPress users and design system management.">
     <meta property="twitter:image" content="./og-image.png">
-    
+
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="./assets/icons/favicon.png">
     <link rel="apple-touch-icon" href="./assets/icons/favicon.png">
     <link rel="manifest" href="./site.webmanifest">
-    
+
     <!-- Preconnect to external domains for performance -->
     <link rel="preconnect" href="https://cdnjs.cloudflare.com">
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
-    
+
     <!-- External Libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Sortable/1.15.2/Sortable.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
@@ -50,6 +55,7 @@
     <!-- Your Stylesheet -->
     <link rel="stylesheet" href="app.css">
 </head>
+
 <body>
 
     <div id="app-container" class="app-container">
@@ -59,7 +65,8 @@
             <div class="search-bar">
                 <i id="search-icon" class="icon"></i>
                 <input type="text" id="search-input" placeholder="Search all variables...">
-                <button class="icon-btn" id="clear-search-btn" style="display: none;"><i class="icon" id="icon-x"></i></button>
+                <button class="icon-btn" id="clear-search-btn" style="display: none;"><i class="icon"
+                        id="icon-x"></i></button>
             </div>
             <div class="header-actions">
                 <button id="import-code-btn" class="main-btn btn-secondary">Import from Code</button>
@@ -67,7 +74,8 @@
                 <button id="export-json-btn" class="main-btn btn-primary">Export JSON</button>
                 <button id="export-css-btn" class="main-btn btn-primary">Export CSS</button>
                 <div style="width: 1px; height: 24px; background: var(--border-primary);"></div>
-                <button id="reset-app-btn" class="icon-btn" title="Reset App"><i id="icon-reset" class="icon"></i></button>
+                <button id="reset-app-btn" class="icon-btn" title="Reset App"><i id="icon-reset"
+                        class="icon"></i></button>
             </div>
         </header>
 
@@ -78,10 +86,13 @@
                 <div class="panel-header">
                     <div class="panel-title">Categories</div>
                     <div class="category-panel-actions">
-                        <button class="icon-btn" id="clear-category-selection-btn" title="Clear selection"><i class="icon" id="icon-cat-clear-selection"></i></button>
-                        <button class="icon-btn" id="bulk-delete-category-btn" title="Delete selected categories"><i class="icon" id="icon-cat-bulk-delete"></i></button>
+                        <button class="icon-btn" id="clear-category-selection-btn" title="Clear selection"><i
+                                class="icon" id="icon-cat-clear-selection"></i></button>
+                        <button class="icon-btn" id="bulk-delete-category-btn" title="Delete selected categories"><i
+                                class="icon" id="icon-cat-bulk-delete"></i></button>
                     </div>
-                    <button id="add-category-btn" class="main-btn btn-secondary" style="padding: 4px 10px;">Add new</button>
+                    <button id="add-category-btn" class="main-btn btn-secondary" style="padding: 4px 10px;">Add
+                        new</button>
                 </div>
                 <div id="categories-list" class="panel-content"></div>
             </div>
@@ -92,15 +103,21 @@
                     <div id="variables-title" class="panel-title">Variables (0)</div>
                     <div class="header-actions">
                         <input type="checkbox" id="select-all-vars-checkbox" title="Select all in view">
-                        <button class="icon-btn" id="clear-selection-btn" title="Clear selection"><i class="icon" id="icon-clear-selection"></i></button>
-                        <button class="icon-btn" id="bulk-delete-btn" title="Delete selected"><i class="icon" id="icon-bulk-delete"></i></button>
-                        <div style="width: 1px; height: 20px; background: var(--border-secondary); margin: 0 4px;"></div>
+                        <button class="icon-btn" id="clear-selection-btn" title="Clear selection"><i class="icon"
+                                id="icon-clear-selection"></i></button>
+                        <button class="icon-btn" id="bulk-delete-btn" title="Delete selected"><i class="icon"
+                                id="icon-bulk-delete"></i></button>
+                        <div style="width: 1px; height: 20px; background: var(--border-secondary); margin: 0 4px;">
+                        </div>
                         <div class="view-toggle">
-                           <button class="icon-btn" id="view-grid-btn" title="Grid View"><i class="icon" id="icon-grid-view"></i></button>
-                           <button class="icon-btn" id="view-row-btn" title="Row View (for reordering)"><i class="icon" id="icon-row-view"></i></button>
+                            <button class="icon-btn" id="view-grid-btn" title="Grid View"><i class="icon"
+                                    id="icon-grid-view"></i></button>
+                            <button class="icon-btn" id="view-row-btn" title="Row View (for reordering)"><i class="icon"
+                                    id="icon-row-view"></i></button>
                         </div>
                     </div>
-                     <button id="add-variable-btn" class="main-btn btn-primary" style="padding: 6px 12px;">Add Variable</button>
+                    <button id="add-variable-btn" class="main-btn btn-primary" style="padding: 6px 12px;">Add
+                        Variable</button>
                 </header>
                 <div id="variables-canvas" class="variables-canvas"></div>
             </div>
@@ -115,12 +132,14 @@
                     <div class="prop-tab" data-tab="categorize">Categorize</div>
                 </div>
                 <div id="prop-edit-content" class="prop-content" data-tab-content="edit"></div>
-                <div id="prop-categorize-content" class="prop-content" data-tab-content="categorize" style="display: none;">
+                <div id="prop-categorize-content" class="prop-content" data-tab-content="categorize"
+                    style="display: none;">
                     <div class="form-group">
                         <label for="move-category-select">Move selected to category:</label>
                         <select id="move-category-select"></select>
                     </div>
-                    <button id="apply-move-btn" class="main-btn btn-primary" style="width: 100%;">Move Variables</button>
+                    <button id="apply-move-btn" class="main-btn btn-primary" style="width: 100%;">Move
+                        Variables</button>
                 </div>
             </div>
         </main>
@@ -138,7 +157,8 @@
                 <input type="hidden" id="variable-id">
                 <div class="form-group">
                     <label for="variable-name">Name (e.g., str-primary-500)</label>
-                    <input type="text" id="variable-name" required pattern="^[a-zA-Z0-9-]*$" title="Only letters, numbers, and hyphens are allowed.">
+                    <input type="text" id="variable-name" required pattern="^[a-zA-Z0-9-]*$"
+                        title="Only letters, numbers, and hyphens are allowed.">
                 </div>
                 <div class="form-group">
                     <label for="variable-value">Value</label>
@@ -153,15 +173,16 @@
                 </div>
                 <div class="modal-actions">
                     <button type="button" class="main-btn btn-secondary" data-modal-close>Cancel</button>
-                    <button type="submit" id="variable-modal-save-btn" class="main-btn btn-primary">Save Variable</button>
+                    <button type="submit" id="variable-modal-save-btn" class="main-btn btn-primary">Save
+                        Variable</button>
                 </div>
             </form>
         </div>
     </div>
-    
+
     <!-- Delete Confirmation Modal -->
     <div id="delete-confirm-modal" class="modal-overlay">
-         <div class="modal">
+        <div class="modal">
             <div class="modal-header">
                 <h3 id="delete-confirm-title">Confirm Action</h3>
                 <button class="close-btn" data-modal-close>×</button>
@@ -170,11 +191,12 @@
             <div id="delete-confirm-details"></div>
             <div class="modal-actions">
                 <button type="button" class="main-btn btn-secondary" id="delete-confirm-cancel-btn">Cancel</button>
-                <button id="delete-confirm-btn" class="main-btn" style="background-color: var(--accent-danger); color: var(--white);">Delete</button>
+                <button id="delete-confirm-btn" class="main-btn"
+                    style="background-color: var(--accent-danger); color: var(--white);">Delete</button>
             </div>
         </div>
     </div>
-    
+
     <!-- Code Modals (Import/Export) -->
     <div id="code-modal" class="modal-overlay">
         <div class="modal" style="max-width: 800px;">
@@ -187,11 +209,11 @@
             <div class="modal-actions" id="code-modal-actions"></div>
         </div>
     </div>
-    
+
     <!-- Import JSON Modal -->
     <div id="import-json-modal" class="modal-overlay">
         <div class="modal">
-             <div class="modal-header">
+            <div class="modal-header">
                 <h3>Import Bricks JSON</h3>
                 <button class="close-btn" data-modal-close>×</button>
             </div>
@@ -200,7 +222,7 @@
                 <p style="font-size: 2rem; margin: 0;">📤</p>
                 <p><strong>Drag & drop your JSON file here</strong><br>or click to select a file</p>
             </div>
-             <div class="modal-actions">
+            <div class="modal-actions">
                 <button type="button" class="main-btn btn-secondary" data-modal-close>Cancel</button>
             </div>
         </div>
@@ -213,4 +235,5 @@
     <script src="app.js"></script>
 
 </body>
+
 </html>


### PR DESCRIPTION
- Add category dropdown to CSS import modal with custom styling
- Implement category selection for CSS export with multi-select interface
- Add JSON export category selection with uncategorized renaming prompt
- Create custom-styled select components matching app theme
- Maintain existing JSON import functionality unchanged
- Skip empty categories in JSON exports to prevent conflicts
- Add proper form validation and user feedback for all flows

Resolves import/export category management requirements while preserving existing functionality and maintaining consistent UI/UX patterns.